### PR TITLE
Restore directory optimization

### DIFF
--- a/setuptools_git/__init__.py
+++ b/setuptools_git/__init__.py
@@ -80,11 +80,23 @@ def gitlsfiles(dirname=''):
     return res
 
 
-def listfiles(dirname=''):
-    git_files = gitlsfiles(dirname)
+def _gitlsdirs(files, prefix_length):
+    # Return directories managed by Git
+    dirs = set()
+    for file in files:
+        dir = posixpath.dirname(file)
+        while len(dir) > prefix_length:
+            dirs.add(dir)
+            dir = posixpath.dirname(dir)
+    return dirs
 
+
+def listfiles(dirname=''):
     cwd = realpath(dirname or os.curdir)
     prefix_length = len(cwd) + 1
+
+    git_files = gitlsfiles(dirname)
+    git_dirs = _gitlsdirs(git_files, prefix_length)
 
     if sys.version_info >= (2, 6):
         walker = os.walk(cwd, followlinks=True)
@@ -92,6 +104,7 @@ def listfiles(dirname=''):
         walker = os.walk(cwd)
 
     for root, dirs, files in walker:
+        dirs[:] = [x for x in dirs if posix(realpath(join(root, x))) in git_dirs]
         for file in files:
             filename = join(root, file)
             if posix(realpath(filename)) in git_files:

--- a/setuptools_git/tests.py
+++ b/setuptools_git/tests.py
@@ -168,19 +168,23 @@ class gitlsfiles_tests(GitTestCase):
                      posix(realpath('../subdir/entry.txt'))]))
 
     def test_directory_only_contains_another_directory(self):
+        self.create_git_file('root.txt')
         self.create_dir('foo', 'bar')
-        self.create_git_file('foo', 'bar', 'root.txt')
+        self.create_git_file('foo', 'bar', 'entry.txt')
         self.assertEqual(
             set(self.gitlsfiles()),
-            set([posix(realpath('foo/bar/root.txt'))]))
+            set([posix(realpath('root.txt')),
+                 posix(realpath('foo/bar/entry.txt'))]))
 
     def test_directory_only_contains_another_directory_in_subdir(self):
+        self.create_git_file('root.txt')
         self.create_dir('foo', 'bar', 'baz')
-        self.create_git_file('foo', 'bar', 'baz', 'root.txt')
+        self.create_git_file('foo', 'bar', 'baz', 'entry.txt')
         os.chdir('foo')
         self.assertEqual(
             set(self.gitlsfiles()),
-            set([posix(realpath('../foo/bar/baz/root.txt'))]))
+            set([posix(realpath('../root.txt')),
+                 posix(realpath('../foo/bar/baz/entry.txt'))]))
 
     def test_git_error(self):
         import setuptools_git
@@ -316,21 +320,22 @@ class listfiles_tests(GitTestCase):
                 set(['entry.txt']))
 
     def test_directory_only_contains_another_directory(self):
+        self.create_git_file('root.txt')
         self.create_dir('foo', 'bar')
-        self.create_git_file('foo', 'bar', 'root.txt')
+        self.create_git_file('foo', 'bar', 'entry.txt')
         self.assertEqual(
             set(self.listfiles()),
-            set([join('foo', 'bar', 'root.txt')])
-            )
+            set(['root.txt',
+                 join('foo', 'bar', 'entry.txt')]))
 
     def test_directory_only_contains_another_directory_in_subdir(self):
+        self.create_git_file('root.txt')
         self.create_dir('foo', 'bar', 'baz')
-        self.create_git_file('foo', 'bar', 'baz', 'root.txt')
+        self.create_git_file('foo', 'bar', 'baz', 'entry.txt')
         os.chdir('foo')
         self.assertEqual(
             set(self.listfiles()),
-            set([join('bar', 'baz', 'root.txt')])
-            )
+            set([join('bar', 'baz', 'entry.txt')]))
 
     def test_git_error(self):
         import setuptools_git

--- a/setuptools_git/tests.py
+++ b/setuptools_git/tests.py
@@ -61,7 +61,7 @@ class gitlsfiles_tests(GitTestCase):
 
     def test_at_repo_root_with_subdir(self):
         self.create_git_file('root.txt')
-        os.mkdir(join(self.directory, 'subdir'))
+        self.create_dir('subdir')
         self.create_git_file('subdir', 'entry.txt')
         self.assertEqual(
                 set(self.gitlsfiles(self.directory)),
@@ -70,7 +70,7 @@ class gitlsfiles_tests(GitTestCase):
 
     def test_at_repo_subdir(self):
         self.create_git_file('root.txt')
-        os.mkdir(join(self.directory, 'subdir'))
+        self.create_dir('subdir')
         self.create_git_file('subdir', 'entry.txt')
         self.assertEqual(
                 set(self.gitlsfiles(join(self.directory, 'subdir'))),
@@ -157,23 +157,30 @@ class gitlsfiles_tests(GitTestCase):
                 set(self.gitlsfiles()),
                 set([posix(realpath('root.txt'))]))
 
-    def test_directory_only_contains_another_directory(self):
-        self.create_dir('foo/bar')
-        self.create_git_file('foo/bar/root.txt')
-        self.assertEqual(
-            set(self.gitlsfiles()),
-            set([posix(realpath(join('foo', 'bar', 'root.txt')))])
-            )
-
     def test_empty_dirname_in_subdir(self):
         self.create_git_file('root.txt')
-        os.mkdir(join(self.directory, 'subdir'))
+        self.create_dir('subdir')
         self.create_git_file('subdir', 'entry.txt')
-        os.chdir(join(self.directory, 'subdir'))
+        os.chdir('subdir')
         self.assertEqual(
                 set(self.gitlsfiles()),
                 set([posix(realpath('../root.txt')),
                      posix(realpath('../subdir/entry.txt'))]))
+
+    def test_directory_only_contains_another_directory(self):
+        self.create_dir('foo', 'bar')
+        self.create_git_file('foo', 'bar', 'root.txt')
+        self.assertEqual(
+            set(self.gitlsfiles()),
+            set([posix(realpath('foo/bar/root.txt'))]))
+
+    def test_directory_only_contains_another_directory_in_subdir(self):
+        self.create_dir('foo', 'bar', 'baz')
+        self.create_git_file('foo', 'bar', 'baz', 'root.txt')
+        os.chdir('foo')
+        self.assertEqual(
+            set(self.gitlsfiles()),
+            set([posix(realpath('../foo/bar/baz/root.txt'))]))
 
     def test_git_error(self):
         import setuptools_git
@@ -205,7 +212,7 @@ class listfiles_tests(GitTestCase):
 
     def test_at_repo_root_with_subdir(self):
         self.create_git_file('root.txt')
-        os.mkdir(join(self.directory, 'subdir'))
+        self.create_dir('subdir')
         self.create_git_file('subdir', 'entry.txt')
         self.assertEqual(
                 set(self.listfiles(self.directory)),
@@ -213,7 +220,7 @@ class listfiles_tests(GitTestCase):
 
     def test_at_repo_subdir(self):
         self.create_git_file('root.txt')
-        os.mkdir(join(self.directory, 'subdir'))
+        self.create_dir('subdir')
         self.create_git_file('subdir', 'entry.txt')
         self.assertEqual(
                 set(self.listfiles(join(self.directory, 'subdir'))),
@@ -299,22 +306,31 @@ class listfiles_tests(GitTestCase):
                 set(self.listfiles()),
                 set(['root.txt']))
 
+    def test_empty_dirname_in_subdir(self):
+        self.create_git_file('root.txt')
+        self.create_dir('subdir')
+        self.create_git_file('subdir', 'entry.txt')
+        os.chdir('subdir')
+        self.assertEqual(
+                set(self.listfiles()),
+                set(['entry.txt']))
+
     def test_directory_only_contains_another_directory(self):
-        self.create_dir('foo/bar')
-        self.create_git_file('foo/bar/root.txt')
+        self.create_dir('foo', 'bar')
+        self.create_git_file('foo', 'bar', 'root.txt')
         self.assertEqual(
             set(self.listfiles()),
             set([join('foo', 'bar', 'root.txt')])
             )
 
-    def test_empty_dirname_in_subdir(self):
-        self.create_git_file('root.txt')
-        os.mkdir(join(self.directory, 'subdir'))
-        self.create_git_file('subdir', 'entry.txt')
-        os.chdir(join(self.directory, 'subdir'))
+    def test_directory_only_contains_another_directory_in_subdir(self):
+        self.create_dir('foo', 'bar', 'baz')
+        self.create_git_file('foo', 'bar', 'baz', 'root.txt')
+        os.chdir('foo')
         self.assertEqual(
-                set(self.listfiles()),
-                set(['entry.txt']))
+            set(self.listfiles()),
+            set([join('bar', 'baz', 'root.txt')])
+            )
 
     def test_git_error(self):
         import setuptools_git


### PR DESCRIPTION
This pull request again prevents walking of unmanaged directories.

I must say I am no longer happy with how this turned out. Three quarters of the code, and two thirds of the runtime, are spent supporting symlinks. I am especially concerned about the latter because, thanks to how setuptools works, the plugin is invoked by nearly every setup.py command. You (@wichert) seem to be the only person in the world using that feature. What's wrong with Git submodules anyway? ;-)

I'd much prefer to rip it out like I have done on my [no-symlinks](https://github.com/stefanholek/setuptools-git/compare/master...no-symlinks) branch.

/cc @mcdonc
