### PR TITLE
Add ability to get version from git tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,8 @@ setup(
     entry_points="""
         [setuptools.file_finders]
         git=setuptools_git:listfiles
+
+        [distutils.setup_keywords]
+        use_vcs_version=setuptools_git:version_calc
         """
 )

--- a/setuptools_git/__init__.py
+++ b/setuptools_git/__init__.py
@@ -18,6 +18,19 @@ from setuptools_git.utils import decompose
 from setuptools_git.utils import CalledProcessError
 
 
+def version_calc(dist, attr, value):
+    """
+    Handler for parameter to setup(use_vcs_version=value)
+    bool(value) should be true to invoke this plugin.
+    """
+    if attr == 'use_vcs_version' and value:
+        dist.metadata.version = calculate_version()
+
+
+def calculate_version():
+    return check_output(['git', 'describe', '--tags', '--dirty']).strip()
+
+
 def ntfsdecode(path):
     # We receive the raw bytes from Git and must decode by hand
     if sys.version_info >= (3,):


### PR DESCRIPTION
if `setup` is called with `use_vcs_version=True`, then the version is obtained by doing `git describe --tags --dirty`.

e.g.:

``` python
# setup.py

from setuptools import setup

setup(name='profilesvc',
      use_vcs_version=True)
```

```
$ python setup.py egg_info; grep '^Version:' profilesvc.egg-info/PKG-INFO
...
Version: v23.0.2-develop-4-g79f3bc0-dirty
```

Note that the generated version comes directly from `git describe --tags --dirty`:

```
$ git describe --tags --dirty
v23.0.2-develop-4-g79f3bc0-dirty
```

This version means that I am on the `develop` branch 4 commits after the `v23.0.2` tag. The hash is `79f3bc0` and the working directory is dirty.

This borrows code from https://bitbucket.org/jaraco/hgtools

Cc: @sudarkoff, @ygingras, @jaraco
