### PR TITLE
Return early if a directory isn't managed by git

### DIFF
--- a/setuptools_git/__init__.py
+++ b/setuptools_git/__init__.py
@@ -82,6 +82,8 @@ def gitlsfiles(dirname=''):
 
 def listfiles(dirname=''):
     git_files = gitlsfiles(dirname)
+    if not git_files:
+        return
 
     cwd = realpath(dirname or os.curdir)
     prefix_length = len(cwd) + 1


### PR DESCRIPTION
This makes things much faster for large non-git trees that happen to
have setuptools_git among their indirect requirements.  For example,
this takes Launchpad's "python setup.py egg_info" from 16 seconds to 2
seconds for me.

https://github.com/msabramo/setuptools-git/pull/6 would probably help as well, not to mention optimising the realpath handling so that it doesn't unnecessarily re-stat every path element for every file in your tree, which is a candidate for http://accidentallyquadratic.tumblr.com/ .  But this is easy and non-intrusive.
