### PR TITLE
Optimize directory scanning to skip ignored directories

### DIFF
--- a/setuptools_git/__init__.py
+++ b/setuptools_git/__init__.py
@@ -80,6 +80,17 @@ def gitlsfiles(dirname=''):
     return res
 
 
+def _gitlsdirs(files, prefix_length):
+    # Return directories managed by Git
+    dirs = set()
+    for file in files:
+        dir = posixpath.dirname(file)
+        while len(dir) > prefix_length:
+            dirs.add(dir)
+            dir = posixpath.dirname(dir)
+    return dirs
+
+
 def listfiles(dirname=''):
     git_files = gitlsfiles(dirname)
     if not git_files:
@@ -88,12 +99,15 @@ def listfiles(dirname=''):
     cwd = realpath(dirname or os.curdir)
     prefix_length = len(cwd) + 1
 
+    git_dirs = _gitlsdirs(git_files, prefix_length)
+
     if sys.version_info >= (2, 6):
         walker = os.walk(cwd, followlinks=True)
     else:
         walker = os.walk(cwd)
 
     for root, dirs, files in walker:
+        dirs[:] = [x for x in dirs if posix(realpath(join(root, x))) in git_dirs]
         for file in files:
             filename = join(root, file)
             if posix(realpath(filename)) in git_files:

--- a/setuptools_git/tests.py
+++ b/setuptools_git/tests.py
@@ -61,7 +61,7 @@ class gitlsfiles_tests(GitTestCase):
 
     def test_at_repo_root_with_subdir(self):
         self.create_git_file('root.txt')
-        os.mkdir(join(self.directory, 'subdir'))
+        self.create_dir('subdir')
         self.create_git_file('subdir', 'entry.txt')
         self.assertEqual(
                 set(self.gitlsfiles(self.directory)),
@@ -70,7 +70,7 @@ class gitlsfiles_tests(GitTestCase):
 
     def test_at_repo_subdir(self):
         self.create_git_file('root.txt')
-        os.mkdir(join(self.directory, 'subdir'))
+        self.create_dir('subdir')
         self.create_git_file('subdir', 'entry.txt')
         self.assertEqual(
                 set(self.gitlsfiles(join(self.directory, 'subdir'))),
@@ -167,7 +167,7 @@ class gitlsfiles_tests(GitTestCase):
 
     def test_empty_dirname_in_subdir(self):
         self.create_git_file('root.txt')
-        os.mkdir(join(self.directory, 'subdir'))
+        self.create_dir('subdir')
         self.create_git_file('subdir', 'entry.txt')
         os.chdir(join(self.directory, 'subdir'))
         self.assertEqual(
@@ -205,7 +205,7 @@ class listfiles_tests(GitTestCase):
 
     def test_at_repo_root_with_subdir(self):
         self.create_git_file('root.txt')
-        os.mkdir(join(self.directory, 'subdir'))
+        self.create_dir('subdir')
         self.create_git_file('subdir', 'entry.txt')
         self.assertEqual(
                 set(self.listfiles(self.directory)),
@@ -213,7 +213,7 @@ class listfiles_tests(GitTestCase):
 
     def test_at_repo_subdir(self):
         self.create_git_file('root.txt')
-        os.mkdir(join(self.directory, 'subdir'))
+        self.create_dir('subdir')
         self.create_git_file('subdir', 'entry.txt')
         self.assertEqual(
                 set(self.listfiles(join(self.directory, 'subdir'))),
@@ -309,7 +309,7 @@ class listfiles_tests(GitTestCase):
 
     def test_empty_dirname_in_subdir(self):
         self.create_git_file('root.txt')
-        os.mkdir(join(self.directory, 'subdir'))
+        self.create_dir('subdir')
         self.create_git_file('subdir', 'entry.txt')
         os.chdir(join(self.directory, 'subdir'))
         self.assertEqual(


### PR DESCRIPTION
This avoids walking possibly large folders like node_modules, which becomes especially important when working on NFS or shared-folder mounts. This is basically #6 rebased onto the latest `master` branch.