### PR TITLE
repos with symlinks not working anymore since #12

### DIFF
--- a/setuptools_git/tests.py
+++ b/setuptools_git/tests.py
@@ -46,6 +46,13 @@ class GitTestCase(unittest.TestCase):
         check_call(['git', 'add', filename])
         check_call(['git', 'commit', '--quiet', '-m', 'add new file'])
 
+    def create_git_symlink(self, source, *path):
+        from setuptools_git.utils import check_call
+        link_name = join(*path)
+        os.symlink(source, link_name)
+        check_call(['git', 'add', link_name])
+        check_call(['git', 'commit', '--quiet', '-m', 'add new symlink'])
+
 
 class gitlsfiles_tests(GitTestCase):
 
@@ -315,6 +322,16 @@ class listfiles_tests(GitTestCase):
         self.assertEqual(
                 set(self.listfiles()),
                 set(['entry.txt']))
+
+    def test_symlink(self):
+        self.create_dir('datadir')
+        self.create_git_file('datadir', 'entry.txt')
+        self.create_dir('subdir')
+        self.create_git_symlink('../datadir', 'subdir', 'datadir')
+        os.chdir(join(self.directory, 'subdir'))
+        self.assertEqual(
+                set(self.listfiles()),
+                set([join('datadir', 'entry.txt')]))
 
     def test_git_error(self):
         import setuptools_git

--- a/setuptools_git/tests.py
+++ b/setuptools_git/tests.py
@@ -324,6 +324,8 @@ class listfiles_tests(GitTestCase):
                 set(['entry.txt']))
 
     def test_symlink(self):
+        if sys.platform == 'win32':
+            return
         self.create_dir('datadir')
         self.create_git_file('datadir', 'entry.txt')
         self.create_dir('subdir')


### PR DESCRIPTION
Here is a test illustrating a use case that was working with 1.1 and is broken with 1.2.

Reverting https://github.com/msabramo/setuptools-git/commit/4885c6575b7a5b7c989450829fb15078fddab34d makes the test pass.

Now looking for a proper fix.