### PR TITLE
Python3 bytes to string decode() fixes bug

### DIFF
--- a/setuptools_git/__init__.py
+++ b/setuptools_git/__init__.py
@@ -28,7 +28,7 @@ def version_calc(dist, attr, value):
 
 
 def calculate_version():
-    return check_output(['git', 'describe', '--tags', '--dirty']).strip()
+    return check_output(['git', 'describe', '--tags', '--dirty']).decode().strip()
 
 
 def ntfsdecode(path):
@@ -65,20 +65,21 @@ def gitlsfiles(dirname=''):
     try:
         topdir = check_output(
             ['git', 'rev-parse', '--show-toplevel'], cwd=dirname or None,
-            stderr=PIPE).strip()
+            stderr=PIPE).decode().strip()
 
         if sys.platform == 'win32':
             cwd = ntfsdecode(topdir)
         else:
             cwd = topdir
 
-        filenames = check_output(
+        zfilenames = check_output(
             ['git', 'ls-files', '-z'], cwd=cwd, stderr=PIPE)
     except (CalledProcessError, OSError):
         # Setuptools mandates we fail silently
         return res
 
-    for filename in filenames.split(b('\x00')):
+    for bfilename in zfilenames.split(b('\x00')):
+        filename = bfilename.decode()
         if filename:
             filename = posixpath.join(topdir, filename)
             if sys.platform == 'darwin':


### PR DESCRIPTION
`check_output()` returns `bytes` on Python 3 and `str` on Python 2, leading to problems with `calculate_version()` and `gitlsfiles()`. Both error in this way:

```
  File "/usr/lib/python3/dist-packages/setuptools/command/egg_info.py", line 69, in finalize_options

    self.egg_version = self.tagged_version()

  File "/usr/lib/python3/dist-packages/setuptools/command/egg_info.py", line 154, in tagged_version

    return safe_version(version + self.vtags)

TypeError: can't concat bytes to str
```

Tested on Python 2.7, 3.4 and 3.5

I presume unicode is desired internally. `check_version()` can be fixed with `.decode()` added, but an issue came up where I don't know the best practice. Since `getlsfiles()` uses null-delimited filenames, and HFS Plus needs an extra step to decode to unicode, is one of these preferred:

```
[ hfs_quote(s) for s in check_output(...).decode().split('\x00') ]
[ hfs_quote(s.decode()) for s in check_output(...).split('\x00') ]
```